### PR TITLE
Fix move scoring to prefer faster wins

### DIFF
--- a/server/src/main.cpp
+++ b/server/src/main.cpp
@@ -88,8 +88,9 @@ static int search(int d,int a,int b,int p){
     auto it = ttable.find(key);
     if(it!=ttable.end() && it->second.depth>=d) return it->second.score;
 
-    if(is_win(1)) return 1000-d;
-    if(is_win(2)) return -1000+d;
+    // prefer quicker wins for both players by scaling with depth
+    if(is_win(1)) return 1000+d;   // larger score for faster win
+    if(is_win(2)) return -1000-d;  // smaller score for faster win
     bool full=true; for(int c=0;c<7;c++) if(is_valid(c)){ full=false; break; }
     if(full||d==0) {
         int val = eval();


### PR DESCRIPTION
## Summary
- adjust win scores in minimax search

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `bash ./server/test.sh` *(fails: Couldn't connect to server without starting server)*
- `bash ./server/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_685a601b142c832099ff1e0a6acb605e